### PR TITLE
trying to fix line 166

### DIFF
--- a/libraries/windows_updates.rb
+++ b/libraries/windows_updates.rb
@@ -163,7 +163,7 @@ $updates = $searcher.Updates | ForEach-Object {
 }
 $updates | ConvertTo-Json
     EOH
-    cmd = inspec.powershell(script)
+    cmd = @inspec.powershell(script)
 
     begin
       @cache_available = JSON.parse(cmd.stdout)


### PR DESCRIPTION
`bundle exec inspec exec https://github.com/dev-sec/windows-patch-benchmark --password=<secret> -t winrm://administrator@54.17.29.2`

```
[2016-10-01T16:40:39-07:00] WARN: URL target https://github.com/dev-sec/windows-patch-benchmark transformed to https://github.com/dev-sec/windows-patch-benchmark/archive/master.tar.gz. Consider using the git fetcher
bundler: failed to load command: inspec (/Users/rmicone/.gem/ruby/2.2.3/bin/inspec)
NameError: undefined local variable or method `inspec' for #<#<Class:0x007fc5d65995b8>::Windows2012UpdateFetcher:0x007fc5d65ba588>
  libraries/windows_updates.rb:166:in `fetchUpdates'
  libraries/windows_updates.rb:109:in `fetchUpdates'
  libraries/windows_updates.rb:58:in `all'
  windows-patch-benchmark-master/controls/patches.rb:15:in `block in load_with_context'
```

tests run cleanly after

```


Profile: Windows Patch Benchmark (windows-patch-benchmark)
Version: 0.3.0
Target:  winrm://administrator@http://54.177.219.42:5985/wsman:3389


Profile Summary: 0 successful, 5 failures, 0 skipped
```
