### PR TITLE
Bump version to 0.5.0 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**/.librarian
+**/Puppetfile.lock
+**/.tmp
+Gemfile.lock
+Berksfile.lock
+inspec.lock
+nbproject

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
   - 'vendor/**/*'
 Documentation:
   Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
 AlignParameters:
   Enabled: true
 Encoding:
@@ -38,9 +40,9 @@ Style/PercentLiteralDelimiters:
     '%w': '{}'
     '%W': ()
     '%x': ()
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
@@ -56,9 +58,9 @@ Style/AndOr:
   Enabled: false
 Style/Not:
   Enabled: false
-Style/FileName:
+Naming/FileName:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
@@ -68,7 +70,7 @@ Style/UnlessElse:
   Enabled: false
 BlockDelimiters:
   Enabled: false
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [0.5.0](https://github.com/dev-sec/windows-patch-baseline/tree/0.5.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/windows-patch-baseline/compare/0.4.0...0.5.0)
+
+**Closed issues:**
+
+- Error running against a Azure WIN2012R2 VM [\#8](https://github.com/dev-sec/windows-patch-baseline/issues/8)
+
+**Merged pull requests:**
+
+- Update issue templates [\#11](https://github.com/dev-sec/windows-patch-baseline/pull/11) ([rndmh3ro](https://github.com/rndmh3ro))
+- Modify `\#fetch\_updates` to always return an Array [\#10](https://github.com/dev-sec/windows-patch-baseline/pull/10) ([jerryaldrichiii](https://github.com/jerryaldrichiii))
+
 ## [0.4.0](https://github.com/dev-sec/windows-patch-baseline/tree/0.4.0) (2017-05-08)
 [Full Changelog](https://github.com/dev-sec/windows-patch-baseline/compare/0.3.1...0.4.0)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'rack', '1.6.4'
-gem 'inspec', '~> 1'
-gem 'rubocop', '~> 0.46.0'
-gem 'highline', '~> 1.6.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :integration do
   gem 'berkshelf'
@@ -14,5 +16,6 @@ group :integration do
 end
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -20,23 +20,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'windows-patch-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/controls/patches.rb
+++ b/controls/patches.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 # copyright: 2016, Christoph Hartmann
 # license: MPLv2
 #

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
 name: windows-patch-baseline
 title: DevSec Windows Patch Baseline
 summary: Verifies all patches are applied
-version: 0.4.0
+version: 0.5.0
 
 maintainer: Christoph Hartmann
 copyright: Christoph Hartmann


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:
```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```